### PR TITLE
CI: Replace PHP 8.1 with PHP 8.5 in test matrix

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -32,10 +32,10 @@ jobs:
     strategy:
       matrix:
         include:
-          - php-version: '8.1'
           - php-version: '8.2'
           - php-version: '8.3'
           - php-version: '8.4'
+          - php-version: '8.5'
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary

| Change | Details |
|--------|---------|
| **Drop** | PHP 8.1 (EOL since Dec 2025) from CI test matrix |
| **Add** | PHP 8.5 (released Nov 2025, actively supported) to CI test matrix |
| **File** | `.github/workflows/tests.yaml` |

PHP 8.1 is no longer supported and our `composer.json` requires `>=8.2`. PHP 8.5 ensures forward compatibility testing.

Closes #51