### PR TITLE
Fix typo: matrix.php-versions → matrix.php-version

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -44,7 +44,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: ${{ matrix.php-versions }}
+          php-version: ${{ matrix.php-version }}
 
       - name: Create var directory
         run: mkdir -p var


### PR DESCRIPTION
## Summary

| Change | Details |
|--------|---------|
| **Fix** | Typo in `.github/workflows/tests.yaml` line 47 |
| **Before** | `${{ matrix.php-versions }}` (plural) |
| **After** | `${{ matrix.php-version }}` (singular) |

The matrix key is defined as `php-version` (singular), but was referenced as `php-versions` (plural), causing all test jobs to fail.

Addresses comment from PR #53.