### PR TITLE
M1I02: Exception classes

### DIFF
--- a/src/Server/Exception/InvalidConfigurationException.php
+++ b/src/Server/Exception/InvalidConfigurationException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\Forklift\Server\Exception;
+
+use RuntimeException;
+
+class InvalidConfigurationException extends RuntimeException
+{
+}

--- a/src/Server/Exception/SocketAcceptException.php
+++ b/src/Server/Exception/SocketAcceptException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\Forklift\Server\Exception;
+
+use RuntimeException;
+
+class SocketAcceptException extends RuntimeException
+{
+}

--- a/src/Server/Exception/SocketCreationException.php
+++ b/src/Server/Exception/SocketCreationException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\Forklift\Server\Exception;
+
+use RuntimeException;
+
+class SocketCreationException extends RuntimeException
+{
+}

--- a/src/Server/Exception/WorkerFailedException.php
+++ b/src/Server/Exception/WorkerFailedException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\Forklift\Server\Exception;
+
+use RuntimeException;
+
+class WorkerFailedException extends RuntimeException
+{
+}

--- a/tests/Server/Exception/ExceptionTest.php
+++ b/tests/Server/Exception/ExceptionTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\Forklift\Tests\Server\Exception;
+
+use CrazyGoat\Forklift\Server\Exception\InvalidConfigurationException;
+use CrazyGoat\Forklift\Server\Exception\SocketAcceptException;
+use CrazyGoat\Forklift\Server\Exception\SocketCreationException;
+use CrazyGoat\Forklift\Server\Exception\WorkerFailedException;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+class ExceptionTest extends TestCase
+{
+    public function testSocketCreationExceptionExtendsRuntimeException(): void
+    {
+        $exception = new SocketCreationException();
+        $this->assertInstanceOf(SocketCreationException::class, $exception);
+        $this->assertInstanceOf(RuntimeException::class, $exception);
+    }
+
+    public function testSocketAcceptExceptionExtendsRuntimeException(): void
+    {
+        $exception = new SocketAcceptException();
+        $this->assertInstanceOf(SocketAcceptException::class, $exception);
+        $this->assertInstanceOf(RuntimeException::class, $exception);
+    }
+
+    public function testWorkerFailedExceptionExtendsRuntimeException(): void
+    {
+        $exception = new WorkerFailedException();
+        $this->assertInstanceOf(WorkerFailedException::class, $exception);
+        $this->assertInstanceOf(RuntimeException::class, $exception);
+    }
+
+    public function testInvalidConfigurationExceptionExtendsRuntimeException(): void
+    {
+        $exception = new InvalidConfigurationException();
+        $this->assertInstanceOf(InvalidConfigurationException::class, $exception);
+        $this->assertInstanceOf(RuntimeException::class, $exception);
+    }
+
+    public function testExceptionAcceptanceCriteria(): void
+    {
+        $classes = [
+            SocketCreationException::class,
+            SocketAcceptException::class,
+            WorkerFailedException::class,
+            InvalidConfigurationException::class,
+        ];
+
+        $this->assertCount(4, $classes);
+
+        foreach ($classes as $class) {
+            $reflection = new \ReflectionClass($class);
+            $this->assertTrue($reflection->isSubclassOf(RuntimeException::class));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

| | |
|---|---|
| **Issue** | Closes #4 |
| **Milestone** | M1: Core — Types, Socket, Proxy, Protocol |
| **Branch** | `feature/m1i02-exception-classes` |

Adds four exception classes in `src/Server/Exception/`, each extending `\RuntimeException` with an empty body:
- **SocketCreationException** — socket could not be created or bound
- **SocketAcceptException** — connection accept failed
- **WorkerFailedException** — worker process could not start
- **InvalidConfigurationException** — configuration validation failed

## Acceptance checklist

- [x] 4 exception classes, each in its own file
- [x] All extend `\RuntimeException`, empty body
- [x] Namespace: `CrazyGoat\Forklift\Server\Exception`
- [x] No `ProtocolNotSupportedException`
- [x] Tests pass: `composer test`
- [x] Lint passes: `composer lint`

Closes #4