### PR TITLE
M1I03: Socket wrapper

### DIFF
--- a/src/Server/Socket/Connection.php
+++ b/src/Server/Socket/Connection.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\Forklift\Server\Socket;
+
+class Connection
+{
+    private float $lastActivity;
+    private bool $closed = false;
+
+    public function __construct(private readonly \Socket $resource)
+    {
+        $this->lastActivity = \microtime(true);
+    }
+
+    public function read(int $length = 65536): string|false
+    {
+        if ($this->closed) {
+            return false;
+        }
+
+        $data = \socket_read($this->resource, $length);
+        $this->lastActivity = \microtime(true);
+
+        return $data;
+    }
+
+    public function write(string $data): int|false
+    {
+        if ($this->closed) {
+            return false;
+        }
+
+        $result = \socket_write($this->resource, $data, strlen($data));
+        $this->lastActivity = \microtime(true);
+
+        return $result;
+    }
+
+    public function close(): void
+    {
+        if (!$this->closed) {
+            \socket_close($this->resource);
+            $this->closed = true;
+        }
+    }
+
+    public function isClosed(): bool
+    {
+        return $this->closed;
+    }
+
+    /** @return array{host: string, port: int} */
+    public function getPeerName(): array
+    {
+        \socket_getpeername($this->resource, $addr, $port);
+
+        /** @var string $addr */
+        /** @var int $port */
+        return ['host' => $addr, 'port' => $port];
+    }
+
+    public function getLastActivity(): float
+    {
+        return $this->lastActivity;
+    }
+
+    /** @param array<int, mixed>|int|string $value */
+    public function setOption(int $level, int $option, array|int|string $value): void
+    {
+        if ($this->closed) {
+            return;
+        }
+
+        \socket_set_option($this->resource, $level, $option, $value);
+    }
+}

--- a/src/Server/Socket/Connection.php
+++ b/src/Server/Socket/Connection.php
@@ -21,7 +21,10 @@ class Connection
         }
 
         $data = \socket_read($this->resource, $length);
-        $this->lastActivity = \microtime(true);
+
+        if ($data !== false) {
+            $this->lastActivity = \microtime(true);
+        }
 
         return $data;
     }
@@ -33,7 +36,10 @@ class Connection
         }
 
         $result = \socket_write($this->resource, $data, strlen($data));
-        $this->lastActivity = \microtime(true);
+
+        if ($result !== false) {
+            $this->lastActivity = \microtime(true);
+        }
 
         return $result;
     }
@@ -54,7 +60,13 @@ class Connection
     /** @return array{host: string, port: int} */
     public function getPeerName(): array
     {
-        \socket_getpeername($this->resource, $addr, $port);
+        if ($this->closed) {
+            throw new \RuntimeException('Connection is closed');
+        }
+
+        if (!\socket_getpeername($this->resource, $addr, $port)) {
+            throw new \RuntimeException('Failed to get peer name');
+        }
 
         /** @var string $addr */
         /** @var int $port */
@@ -73,6 +85,10 @@ class Connection
             return;
         }
 
-        \socket_set_option($this->resource, $level, $option, $value);
+        if (\socket_set_option($this->resource, $level, $option, $value) === false) {
+            throw new \RuntimeException(
+                \socket_strerror(\socket_last_error($this->resource)),
+            );
+        }
     }
 }

--- a/src/Server/Socket/Socket.php
+++ b/src/Server/Socket/Socket.php
@@ -46,7 +46,11 @@ class Socket
             throw new SocketCreationException('Socket is closed');
         }
 
-        \socket_set_option($this->resource, $level, $option, $value);
+        if (\socket_set_option($this->resource, $level, $option, $value) === false) {
+            throw new SocketCreationException(
+                \socket_strerror(\socket_last_error($this->resource)),
+            );
+        }
     }
 
     public function bind(string $address, int $port): void

--- a/src/Server/Socket/Socket.php
+++ b/src/Server/Socket/Socket.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\Forklift\Server\Socket;
+
+use CrazyGoat\Forklift\Server\Exception\SocketAcceptException;
+use CrazyGoat\Forklift\Server\Exception\SocketCreationException;
+
+class Socket
+{
+    public function __construct(private ?\Socket $resource)
+    {
+    }
+
+    public function accept(): Connection
+    {
+        if (!$this->resource instanceof \Socket) {
+            throw new SocketAcceptException('Socket is closed');
+        }
+
+        $accepted = @\socket_accept($this->resource);
+
+        if ($accepted === false) {
+            throw new SocketAcceptException(
+                \socket_strerror(\socket_last_error($this->resource)),
+            );
+        }
+
+        return new Connection($accepted);
+    }
+
+    public function close(): void
+    {
+        if ($this->resource instanceof \Socket) {
+            \socket_close($this->resource);
+        }
+
+        $this->resource = null;
+    }
+
+    /** @param array<int, mixed>|int|string $value */
+    public function setOption(int $level, int $option, array|int|string $value): void
+    {
+        if (!$this->resource instanceof \Socket) {
+            throw new SocketCreationException('Socket is closed');
+        }
+
+        \socket_set_option($this->resource, $level, $option, $value);
+    }
+
+    public function bind(string $address, int $port): void
+    {
+        if (!$this->resource instanceof \Socket) {
+            throw new SocketCreationException('Socket is closed');
+        }
+
+        if (!\socket_bind($this->resource, $address, $port)) {
+            throw new SocketCreationException(
+                \socket_strerror(\socket_last_error($this->resource)),
+            );
+        }
+    }
+
+    public function listen(int $backlog = SOMAXCONN): void
+    {
+        if (!$this->resource instanceof \Socket) {
+            throw new SocketCreationException('Socket is closed');
+        }
+
+        if (!\socket_listen($this->resource, $backlog)) {
+            throw new SocketCreationException(
+                \socket_strerror(\socket_last_error($this->resource)),
+            );
+        }
+    }
+}

--- a/tests/Server/Socket/SocketTest.php
+++ b/tests/Server/Socket/SocketTest.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\Forklift\Tests\Server\Socket;
+
+use CrazyGoat\Forklift\Server\Exception\SocketAcceptException;
+use CrazyGoat\Forklift\Server\Exception\SocketCreationException;
+use CrazyGoat\Forklift\Server\Socket\Connection;
+use CrazyGoat\Forklift\Server\Socket\Socket;
+use PHPUnit\Framework\TestCase;
+use ReflectionProperty;
+
+class SocketTest extends TestCase
+{
+    public function testConstructorWrapsResource(): void
+    {
+        $resource = \socket_create(AF_INET, SOCK_STREAM, SOL_TCP);
+        $this->assertNotFalse($resource);
+
+        $socket = new Socket($resource);
+
+        $this->assertInstanceOf(Socket::class, $socket);
+
+        \socket_close($resource);
+    }
+
+    public function testBindAndListen(): void
+    {
+        $resource = \socket_create(AF_INET, SOCK_STREAM, SOL_TCP);
+        $this->assertNotFalse($resource);
+
+        $socket = new Socket($resource);
+        $socket->setOption(SOL_SOCKET, SO_REUSEADDR, 1);
+        $socket->bind('127.0.0.1', 0);
+        $socket->listen(5);
+
+        $socket->close();
+    }
+
+    public function testAcceptReturnsConnection(): void
+    {
+        $resource = \socket_create(AF_INET, SOCK_STREAM, SOL_TCP);
+        $this->assertNotFalse($resource);
+
+        \socket_set_option($resource, SOL_SOCKET, SO_REUSEADDR, 1);
+        \socket_bind($resource, '127.0.0.1', 0);
+        \socket_getsockname($resource, $addr, $port);
+        $this->assertIsString($addr);
+        $this->assertIsInt($port);
+
+        \socket_listen($resource);
+        $socket = new Socket($resource);
+
+        $client = \socket_create(AF_INET, SOCK_STREAM, SOL_TCP);
+        $this->assertNotFalse($client);
+
+        \socket_connect($client, $addr, $port);
+
+        $connection = $socket->accept();
+
+        $this->assertInstanceOf(Connection::class, $connection);
+
+        \socket_close($client);
+        $connection->close();
+        $socket->close();
+    }
+
+    public function testCloseIsIdempotent(): void
+    {
+        $resource = \socket_create(AF_INET, SOCK_STREAM, SOL_TCP);
+        $this->assertNotFalse($resource);
+
+        $socket = new Socket($resource);
+
+        $socket->close();
+        $socket->close();
+    }
+
+    public function testCloseSetsResourceToNull(): void
+    {
+        $resource = \socket_create(AF_INET, SOCK_STREAM, SOL_TCP);
+        $this->assertNotFalse($resource);
+
+        $socket = new Socket($resource);
+        $socket->close();
+
+        $reflection = new ReflectionProperty(Socket::class, 'resource');
+
+        $this->assertNull($reflection->getValue($socket));
+    }
+
+    public function testAcceptThrowsAfterClose(): void
+    {
+        $resource = \socket_create(AF_INET, SOCK_STREAM, SOL_TCP);
+        $this->assertNotFalse($resource);
+
+        $socket = new Socket($resource);
+        $socket->close();
+
+        $this->expectException(SocketAcceptException::class);
+
+        $socket->accept();
+    }
+
+    public function testBindThrowsAfterClose(): void
+    {
+        $resource = \socket_create(AF_INET, SOCK_STREAM, SOL_TCP);
+        $this->assertNotFalse($resource);
+
+        $socket = new Socket($resource);
+        $socket->close();
+
+        $this->expectException(SocketCreationException::class);
+
+        $socket->bind('127.0.0.1', 8080);
+    }
+
+    public function testListenThrowsAfterClose(): void
+    {
+        $resource = \socket_create(AF_INET, SOCK_STREAM, SOL_TCP);
+        $this->assertNotFalse($resource);
+
+        $socket = new Socket($resource);
+        $socket->close();
+
+        $this->expectException(SocketCreationException::class);
+
+        $socket->listen();
+    }
+
+    public function testSetOptionThrowsAfterClose(): void
+    {
+        $resource = \socket_create(AF_INET, SOCK_STREAM, SOL_TCP);
+        $this->assertNotFalse($resource);
+
+        $socket = new Socket($resource);
+        $socket->close();
+
+        $this->expectException(SocketCreationException::class);
+
+        $socket->setOption(SOL_SOCKET, SO_REUSEADDR, 1);
+    }
+}

--- a/tests/Server/Socket/SocketTest.php
+++ b/tests/Server/Socket/SocketTest.php
@@ -43,14 +43,14 @@ class SocketTest extends TestCase
         $resource = \socket_create(AF_INET, SOCK_STREAM, SOL_TCP);
         $this->assertNotFalse($resource);
 
-        \socket_set_option($resource, SOL_SOCKET, SO_REUSEADDR, 1);
-        \socket_bind($resource, '127.0.0.1', 0);
+        $socket = new Socket($resource);
+        $socket->setOption(SOL_SOCKET, SO_REUSEADDR, 1);
+        $socket->bind('127.0.0.1', 0);
+        $socket->listen();
+
         \socket_getsockname($resource, $addr, $port);
         $this->assertIsString($addr);
         $this->assertIsInt($port);
-
-        \socket_listen($resource);
-        $socket = new Socket($resource);
 
         $client = \socket_create(AF_INET, SOCK_STREAM, SOL_TCP);
         $this->assertNotFalse($client);
@@ -75,6 +75,10 @@ class SocketTest extends TestCase
 
         $socket->close();
         $socket->close();
+
+        $reflection = new ReflectionProperty(Socket::class, 'resource');
+
+        $this->assertNull($reflection->getValue($socket));
     }
 
     public function testCloseSetsResourceToNull(): void


### PR DESCRIPTION
## Summary

| Action | File |
|--------|------|
| Create | src/Server/Socket/Connection.php |
| Create | src/Server/Socket/Socket.php |
| Create | tests/Server/Socket/SocketTest.php |

- Connection wraps a \Socket resource with read/write/close/peer name tracking
- Socket wraps a listen \Socket resource with bind/listen/accept/close/setOption
- Socket::accept() returns Connection, throws SocketAcceptException on failure
- Socket::close() is idempotent, sets resource to null after close
- Socket::setOption() uses 3 parameters matching PHP's socket_set_option
- Exceptions throw SocketCreationException/SocketAcceptException when operations fail

## Acceptance criteria

- [x] accept() returns Connection instance, throws on error
- [x] close() is idempotent, resource set to null
- [x] setOption() has 3 parameters: $level, $option, $value
- [x] SocketTest passes (bind, listen, close, constructor)

Closes #5