### PR TITLE
M1I05: SocketProxyInterface + ReusePortProxy

### DIFF
--- a/src/Server/Socket/ReusePortProxy.php
+++ b/src/Server/Socket/ReusePortProxy.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\Forklift\Server\Socket;
+
+use CrazyGoat\Forklift\Server\Exception\SocketCreationException;
+use CrazyGoat\Forklift\Server\Types\ProtocolType;
+
+class ReusePortProxy implements SocketProxyInterface
+{
+    public function createSocket(int $port, ProtocolType $protocol): Socket
+    {
+        $resource = @\socket_create(AF_INET, SOCK_STREAM, SOL_TCP);
+
+        if ($resource === false) {
+            throw new SocketCreationException(
+                \socket_strerror(\socket_last_error()),
+            );
+        }
+
+        $socket = new Socket($resource);
+
+        $socket->setOption(SOL_SOCKET, SO_REUSEADDR, 1);
+
+        if ($this->isSupported()) {
+            $socket->setOption(SOL_SOCKET, SO_REUSEPORT, 1);
+        }
+
+        $socket->bind('0.0.0.0', $port);
+        $socket->listen(SOMAXCONN);
+
+        return $socket;
+    }
+
+    public function accept(Socket $socket): Connection
+    {
+        return $socket->accept();
+    }
+
+    public function isSupported(): bool
+    {
+        return defined('SO_REUSEPORT') && PHP_OS_FAMILY !== 'Windows';
+    }
+}

--- a/src/Server/Socket/SocketProxyInterface.php
+++ b/src/Server/Socket/SocketProxyInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\Forklift\Server\Socket;
+
+use CrazyGoat\Forklift\Server\Types\ProtocolType;
+
+interface SocketProxyInterface
+{
+    public function createSocket(int $port, ProtocolType $protocol): Socket;
+
+    public function accept(Socket $socket): Connection;
+
+    public function isSupported(): bool;
+}

--- a/tests/Server/Socket/ReusePortProxyTest.php
+++ b/tests/Server/Socket/ReusePortProxyTest.php
@@ -24,10 +24,6 @@ class ReusePortProxyTest extends TestCase
     {
         $proxy = new ReusePortProxy();
 
-        if (!$proxy->isSupported()) {
-            $this->markTestSkipped('SO_REUSEPORT is not supported on this platform');
-        }
-
         $socket = $proxy->createSocket(0, ProtocolType::TCP);
 
         $this->assertInstanceOf(Socket::class, $socket);
@@ -38,10 +34,6 @@ class ReusePortProxyTest extends TestCase
     public function testAcceptReturnsConnection(): void
     {
         $proxy = new ReusePortProxy();
-
-        if (!$proxy->isSupported()) {
-            $this->markTestSkipped('SO_REUSEPORT is not supported on this platform');
-        }
 
         $socket = $proxy->createSocket(0, ProtocolType::TCP);
 

--- a/tests/Server/Socket/ReusePortProxyTest.php
+++ b/tests/Server/Socket/ReusePortProxyTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\Forklift\Tests\Server\Socket;
+
+use CrazyGoat\Forklift\Server\Socket\Connection;
+use CrazyGoat\Forklift\Server\Socket\ReusePortProxy;
+use CrazyGoat\Forklift\Server\Socket\Socket;
+use CrazyGoat\Forklift\Server\Socket\SocketProxyInterface;
+use CrazyGoat\Forklift\Server\Types\ProtocolType;
+use PHPUnit\Framework\TestCase;
+
+class ReusePortProxyTest extends TestCase
+{
+    public function testImplementsInterface(): void
+    {
+        $proxy = new ReusePortProxy();
+
+        $this->assertInstanceOf(SocketProxyInterface::class, $proxy);
+    }
+
+    public function testCreateSocketReturnsSocket(): void
+    {
+        $proxy = new ReusePortProxy();
+
+        if (!$proxy->isSupported()) {
+            $this->markTestSkipped('SO_REUSEPORT is not supported on this platform');
+        }
+
+        $socket = $proxy->createSocket(0, ProtocolType::TCP);
+
+        $this->assertInstanceOf(Socket::class, $socket);
+
+        $socket->close();
+    }
+
+    public function testAcceptReturnsConnection(): void
+    {
+        $proxy = new ReusePortProxy();
+
+        if (!$proxy->isSupported()) {
+            $this->markTestSkipped('SO_REUSEPORT is not supported on this platform');
+        }
+
+        $socket = $proxy->createSocket(0, ProtocolType::TCP);
+
+        \socket_getsockname($this->getSocketResource($socket), $address, $portNumber);
+
+        $client = \socket_create(AF_INET, SOCK_STREAM, SOL_TCP);
+        $this->assertNotFalse($client);
+
+        /** @var string $address */
+        /** @var int $portNumber */
+        \socket_connect($client, $address, $portNumber);
+
+        $connection = $proxy->accept($socket);
+
+        $this->assertInstanceOf(Connection::class, $connection);
+
+        \socket_close($client);
+        $connection->close();
+        $socket->close();
+    }
+
+    public function testIsSupportedFalseOnWindows(): void
+    {
+        $proxy = new ReusePortProxy();
+
+        if (PHP_OS_FAMILY === 'Windows') {
+            $this->assertFalse($proxy->isSupported());
+        } else {
+            $expected = defined('SO_REUSEPORT');
+            $this->assertSame($expected, $proxy->isSupported());
+        }
+    }
+
+    private function getSocketResource(Socket $socket): \Socket
+    {
+        $reflection = new \ReflectionProperty(Socket::class, 'resource');
+
+        $resource = $reflection->getValue($socket);
+        $this->assertInstanceOf(\Socket::class, $resource);
+
+        return $resource;
+    }
+}


### PR DESCRIPTION
## Summary

| File | Action |
|------|--------|
| `src/Server/Socket/SocketProxyInterface.php` | Create — interface with `createSocket()`, `accept()`, `isSupported()` |
| `src/Server/Socket/ReusePortProxy.php` | Create — SO_REUSEADDR + SO_REUSEPORT proxy |
| `tests/Server/Socket/ReusePortProxyTest.php` | Create — unit tests |

## Acceptance criteria

- [x] `SocketProxyInterface` defines 3 methods with correct signatures
- [x] `ReusePortProxy` implements the interface, uses `SO_REUSEADDR` + conditional `SO_REUSEPORT`
- [x] `isSupported()` returns `false` on Windows or when constant undefined
- [x] Tests pass (or skip on unsupported platforms)

Closes #7