### PR TITLE
M1I06: ForkSharedProxy

### DIFF
--- a/src/Server/Socket/ForkSharedProxy.php
+++ b/src/Server/Socket/ForkSharedProxy.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\Forklift\Server\Socket;
+
+use CrazyGoat\Forklift\Server\Exception\SocketCreationException;
+use CrazyGoat\Forklift\Server\Types\ProtocolType;
+
+class ForkSharedProxy implements SocketProxyInterface
+{
+    public function createSocket(int $port, ProtocolType $protocol): Socket
+    {
+        $resource = @\socket_create(AF_INET, SOCK_STREAM, SOL_TCP);
+
+        if ($resource === false) {
+            throw new SocketCreationException(
+                \socket_strerror(\socket_last_error()),
+            );
+        }
+
+        $socket = new Socket($resource);
+
+        $socket->setOption(SOL_SOCKET, SO_REUSEADDR, 1);
+
+        $socket->bind('0.0.0.0', $port);
+        $socket->listen(SOMAXCONN);
+
+        return $socket;
+    }
+
+    public function accept(Socket $socket): Connection
+    {
+        return $socket->accept();
+    }
+
+    public function isSupported(): bool
+    {
+        return true;
+    }
+}

--- a/tests/Server/Socket/ForkSharedProxyTest.php
+++ b/tests/Server/Socket/ForkSharedProxyTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\Forklift\Tests\Server\Socket;
+
+use CrazyGoat\Forklift\Server\Socket\Connection;
+use CrazyGoat\Forklift\Server\Socket\ForkSharedProxy;
+use CrazyGoat\Forklift\Server\Socket\Socket;
+use CrazyGoat\Forklift\Server\Socket\SocketProxyInterface;
+use CrazyGoat\Forklift\Server\Types\ProtocolType;
+use PHPUnit\Framework\TestCase;
+
+class ForkSharedProxyTest extends TestCase
+{
+    public function testImplementsInterface(): void
+    {
+        $proxy = new ForkSharedProxy();
+
+        $this->assertInstanceOf(SocketProxyInterface::class, $proxy);
+    }
+
+    public function testCreateSocketReturnsSocket(): void
+    {
+        $proxy = new ForkSharedProxy();
+
+        $socket = $proxy->createSocket(0, ProtocolType::TCP);
+
+        $this->assertInstanceOf(Socket::class, $socket);
+
+        $socket->close();
+    }
+
+    public function testAcceptReturnsConnection(): void
+    {
+        $proxy = new ForkSharedProxy();
+
+        $socket = $proxy->createSocket(0, ProtocolType::TCP);
+
+        \socket_getsockname($this->getSocketResource($socket), $address, $portNumber);
+
+        $client = \socket_create(AF_INET, SOCK_STREAM, SOL_TCP);
+        $this->assertNotFalse($client);
+
+        /** @var string $address */
+        /** @var int $portNumber */
+        \socket_connect($client, $address, $portNumber);
+
+        $connection = $proxy->accept($socket);
+
+        $this->assertInstanceOf(Connection::class, $connection);
+
+        \socket_close($client);
+        $connection->close();
+        $socket->close();
+    }
+
+    public function testIsSupportedAlwaysTrue(): void
+    {
+        $proxy = new ForkSharedProxy();
+
+        $this->assertTrue($proxy->isSupported());
+    }
+
+    private function getSocketResource(Socket $socket): \Socket
+    {
+        $reflection = new \ReflectionProperty(Socket::class, 'resource');
+
+        $resource = $reflection->getValue($socket);
+        $this->assertInstanceOf(\Socket::class, $resource);
+
+        return $resource;
+    }
+}


### PR DESCRIPTION
## Summary

| Item | Detail |
|------|--------|
| Proxy | ForkSharedProxy |
| Socket option | `SO_REUSEADDR` only (no `SO_REUSEPORT`) |
| Bind | `0.0.0.0:$port` |
| Listen | `SOMAXCONN` |
| `isSupported()` | Always `true` |
| `accept()` | Delegates to `$socket->accept()` |

## Acceptance criteria

- [x] Implements `SocketProxyInterface`
- [x] `isSupported()` always returns `true`
- [x] Uses only `SO_REUSEADDR` (no `SO_REUSEPORT`)
- [x] Test passes on all platforms

Closes #8