### PR TITLE
M1I10: TlsProxy decorator

### DIFF
--- a/src/Server/Socket/TlsProxy.php
+++ b/src/Server/Socket/TlsProxy.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\Forklift\Server\Socket;
+
+use CrazyGoat\Forklift\Server\Exception\SocketCreationException;
+use CrazyGoat\Forklift\Server\Types\ProtocolType;
+
+class TlsProxy implements SocketProxyInterface
+{
+    /**
+     * @param array<string, mixed> $sslContextOptions
+     */
+    public function __construct(
+        private readonly SocketProxyInterface $inner,
+        private readonly string $certFile,
+        private readonly string $keyFile,
+        private readonly array $sslContextOptions = [],
+    ) {
+    }
+
+    public function createSocket(int $port, ProtocolType $protocol): Socket
+    {
+        return $this->inner->createSocket($port, $protocol);
+    }
+
+    public function accept(Socket $socket): Connection
+    {
+        $connection = $this->inner->accept($socket);
+
+        $reflection = new \ReflectionProperty(Connection::class, 'resource');
+        /** @var \Socket $socketResource */
+        $socketResource = $reflection->getValue($connection);
+
+        $stream = @\socket_export_stream($socketResource);
+
+        if ($stream === false) {
+            throw new SocketCreationException('Failed to export socket to stream');
+        }
+
+        \stream_set_timeout($stream, 30);
+
+        \stream_context_set_option($stream, 'ssl', 'local_cert', $this->certFile);
+        \stream_context_set_option($stream, 'ssl', 'local_pk', $this->keyFile);
+
+        foreach ($this->sslContextOptions as $option => $value) {
+            \stream_context_set_option($stream, 'ssl', $option, $value);
+        }
+
+        $result = @\stream_socket_enable_crypto($stream, true, \STREAM_CRYPTO_METHOD_TLS_SERVER);
+
+        if ($result === false) {
+            \fclose($stream);
+            throw new SocketCreationException('TLS handshake failed');
+        }
+
+        return $connection;
+    }
+
+    public function isSupported(): bool
+    {
+        return \function_exists('stream_socket_enable_crypto')
+            && \function_exists('socket_export_stream');
+    }
+}

--- a/src/Server/Socket/TlsProxy.php
+++ b/src/Server/Socket/TlsProxy.php
@@ -25,6 +25,9 @@ class TlsProxy implements SocketProxyInterface
         return $this->inner->createSocket($port, $protocol);
     }
 
+    /**
+     * @throws SocketCreationException
+     */
     public function accept(Socket $socket): Connection
     {
         $connection = $this->inner->accept($socket);
@@ -36,23 +39,49 @@ class TlsProxy implements SocketProxyInterface
         $stream = @\socket_export_stream($socketResource);
 
         if ($stream === false) {
-            throw new SocketCreationException('Failed to export socket to stream');
+            $error = \error_get_last();
+
+            throw new SocketCreationException(
+                \is_array($error) ? $error['message'] : 'Failed to export socket to stream',
+            );
         }
 
         \stream_set_timeout($stream, 30);
 
-        \stream_context_set_option($stream, 'ssl', 'local_cert', $this->certFile);
-        \stream_context_set_option($stream, 'ssl', 'local_pk', $this->keyFile);
+        if (!\stream_context_set_option($stream, 'ssl', 'local_cert', $this->certFile)) {
+            \fclose($stream);
+
+            throw new SocketCreationException('Failed to set SSL context option: local_cert');
+        }
+
+        if (!\stream_context_set_option($stream, 'ssl', 'local_pk', $this->keyFile)) {
+            \fclose($stream);
+
+            throw new SocketCreationException('Failed to set SSL context option: local_pk');
+        }
 
         foreach ($this->sslContextOptions as $option => $value) {
-            \stream_context_set_option($stream, 'ssl', $option, $value);
+            if (!\stream_context_set_option($stream, 'ssl', $option, $value)) {
+                \fclose($stream);
+
+                throw new SocketCreationException(
+                    \sprintf('Failed to set SSL context option: %s', $option),
+                );
+            }
         }
 
         $result = @\stream_socket_enable_crypto($stream, true, \STREAM_CRYPTO_METHOD_TLS_SERVER);
 
         if ($result === false) {
+            $error = \error_get_last();
             \fclose($stream);
-            throw new SocketCreationException('TLS handshake failed');
+
+            throw new SocketCreationException(
+                \sprintf(
+                    'TLS handshake failed: %s',
+                    \is_array($error) ? $error['message'] : 'unknown error',
+                ),
+            );
         }
 
         return $connection;

--- a/tests/Server/Socket/TlsProxyTest.php
+++ b/tests/Server/Socket/TlsProxyTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\Forklift\Tests\Server\Socket;
+
+use CrazyGoat\Forklift\Server\Exception\SocketCreationException;
+use CrazyGoat\Forklift\Server\Socket\Connection;
+use CrazyGoat\Forklift\Server\Socket\Socket;
+use CrazyGoat\Forklift\Server\Socket\SocketProxyInterface;
+use CrazyGoat\Forklift\Server\Socket\TlsProxy;
+use CrazyGoat\Forklift\Server\Types\ProtocolType;
+use PHPUnit\Framework\TestCase;
+
+class TlsProxyTest extends TestCase
+{
+    public function testImplementsInterface(): void
+    {
+        $inner = $this->createMock(SocketProxyInterface::class);
+        $proxy = new TlsProxy($inner, '/tmp/cert.pem', '/tmp/key.pem');
+
+        $this->assertInstanceOf(SocketProxyInterface::class, $proxy);
+    }
+
+    public function testCreateSocketDelegatesToInner(): void
+    {
+        $expectedSocket = $this->createMock(Socket::class);
+
+        $inner = $this->createMock(SocketProxyInterface::class);
+        $inner->expects($this->once())
+            ->method('createSocket')
+            ->with(8080, ProtocolType::TCP)
+            ->willReturn($expectedSocket);
+
+        $proxy = new TlsProxy($inner, '/tmp/cert.pem', '/tmp/key.pem');
+
+        $result = $proxy->createSocket(8080, ProtocolType::TCP);
+
+        $this->assertSame($expectedSocket, $result);
+    }
+
+    public function testAcceptThrowsOnTlsHandshakeFailure(): void
+    {
+        $server = @\socket_create(AF_INET, SOCK_STREAM, SOL_TCP);
+        $this->assertNotFalse($server);
+
+        \socket_bind($server, '127.0.0.1', 0);
+        \socket_listen($server);
+
+        \socket_getsockname($server, $address, $port);
+
+        /** @var string $address */
+        /** @var int $port */
+        $client = @\socket_create(AF_INET, SOCK_STREAM, SOL_TCP);
+        $this->assertNotFalse($client);
+        \socket_connect($client, $address, $port);
+
+        $clientSocket = @\socket_accept($server);
+        $this->assertNotFalse($clientSocket);
+
+        $connection = new Connection($clientSocket);
+
+        $inner = $this->createMock(SocketProxyInterface::class);
+        $inner->expects($this->once())
+            ->method('accept')
+            ->willReturn($connection);
+
+        $mockSocket = $this->createMock(Socket::class);
+
+        $proxy = new TlsProxy($inner, '/tmp/nonexistent-cert.pem', '/tmp/nonexistent-key.pem');
+
+        $this->expectException(SocketCreationException::class);
+        $this->expectExceptionMessage('TLS handshake failed');
+
+        $proxy->accept($mockSocket);
+
+        \socket_close($client);
+        \socket_close($server);
+    }
+
+    public function testIsSupported(): void
+    {
+        $inner = $this->createMock(SocketProxyInterface::class);
+        $proxy = new TlsProxy($inner, '/tmp/cert.pem', '/tmp/key.pem');
+
+        $expected = \function_exists('stream_socket_enable_crypto')
+            && \function_exists('socket_export_stream');
+
+        $this->assertSame($expected, $proxy->isSupported());
+    }
+}


### PR DESCRIPTION
## Summary

| Action | Path |
|--------|------|
| Create | `src/Server/Socket/TlsProxy.php` |
| Create | `tests/Server/Socket/TlsProxyTest.php` |

`TlsProxy` is a decorator wrapping any `SocketProxyInterface` to add SSL/TLS encryption:
- Delegates `createSocket()` to inner proxy
- `accept()` delegates to inner proxy, then `socket_export_stream()` + `stream_socket_enable_crypto()` with 30s timeout
- `isSupported()` checks function availability
- Throws `SocketCreationException` on TLS handshake failure

## Acceptance criteria

- [x] Decorates any `SocketProxyInterface`
- [x] `accept()` calls `stream_socket_enable_crypto()` with `STREAM_CRYPTO_METHOD_TLS_SERVER`
- [x] 30s socket timeout set before TLS handshake
- [x] `isSupported()` checks function availability
- [x] Throws on TLS failure
- [x] Test passes: validates delegate passthrough, `isSupported()`

Closes #10