### PR TITLE
M1I09: SocketFactory (fallback chain)

### DIFF
--- a/src/Server/Socket/SocketFactory.php
+++ b/src/Server/Socket/SocketFactory.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\Forklift\Server\Socket;
+
+use CrazyGoat\Forklift\Server\Types\ProtocolType;
+use CrazyGoat\Forklift\Server\Types\ProxyType;
+
+class SocketFactory
+{
+    public static function create(ProxyType $type, int $port, ProtocolType $protocol): SocketProxyInterface
+    {
+        return match ($type) {
+            ProxyType::REUSE_PORT => self::createReuseOrFallback(),
+            ProxyType::FORK_SHARED => new ForkSharedProxy(),
+            ProxyType::MASTER => new MasterProxy(),
+        };
+    }
+
+    private static function createReuseOrFallback(): SocketProxyInterface
+    {
+        $proxy = new ReusePortProxy();
+
+        if ($proxy->isSupported()) {
+            return $proxy;
+        }
+
+        return new ForkSharedProxy();
+    }
+}

--- a/tests/Server/Socket/SocketFactoryTest.php
+++ b/tests/Server/Socket/SocketFactoryTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\Forklift\Tests\Server\Socket;
+
+use CrazyGoat\Forklift\Server\Socket\ForkSharedProxy;
+use CrazyGoat\Forklift\Server\Socket\MasterProxy;
+use CrazyGoat\Forklift\Server\Socket\ReusePortProxy;
+use CrazyGoat\Forklift\Server\Socket\SocketFactory;
+use CrazyGoat\Forklift\Server\Types\ProtocolType;
+use CrazyGoat\Forklift\Server\Types\ProxyType;
+use PHPUnit\Framework\TestCase;
+
+class SocketFactoryTest extends TestCase
+{
+    public function testCreateMasterReturnsMasterProxy(): void
+    {
+        $proxy = SocketFactory::create(ProxyType::MASTER, 8080, ProtocolType::TCP);
+
+        $this->assertInstanceOf(MasterProxy::class, $proxy);
+    }
+
+    public function testCreateForkSharedReturnsForkSharedProxy(): void
+    {
+        $proxy = SocketFactory::create(ProxyType::FORK_SHARED, 8080, ProtocolType::HTTP);
+
+        $this->assertInstanceOf(ForkSharedProxy::class, $proxy);
+    }
+
+    public function testCreateReusePortFallbacksToForkShared(): void
+    {
+        $proxy = SocketFactory::create(ProxyType::REUSE_PORT, 8080, ProtocolType::HTTP);
+
+        $this->assertTrue($proxy instanceof ReusePortProxy || $proxy instanceof ForkSharedProxy);
+    }
+}

--- a/tests/Server/Socket/SocketFactoryTest.php
+++ b/tests/Server/Socket/SocketFactoryTest.php
@@ -28,10 +28,25 @@ class SocketFactoryTest extends TestCase
         $this->assertInstanceOf(ForkSharedProxy::class, $proxy);
     }
 
-    public function testCreateReusePortFallbacksToForkShared(): void
+    public function testCreateReusePortReturnsReusePortWhenSupported(): void
     {
+        if (!(new ReusePortProxy())->isSupported()) {
+            $this->markTestSkipped('SO_REUSEPORT not supported on this platform');
+        }
+
         $proxy = SocketFactory::create(ProxyType::REUSE_PORT, 8080, ProtocolType::HTTP);
 
-        $this->assertTrue($proxy instanceof ReusePortProxy || $proxy instanceof ForkSharedProxy);
+        $this->assertInstanceOf(ReusePortProxy::class, $proxy);
+    }
+
+    public function testCreateReusePortFallsBackToForkSharedWhenNotSupported(): void
+    {
+        if ((new ReusePortProxy())->isSupported()) {
+            $this->markTestSkipped('SO_REUSEPORT is supported on this platform');
+        }
+
+        $proxy = SocketFactory::create(ProxyType::REUSE_PORT, 8080, ProtocolType::HTTP);
+
+        $this->assertInstanceOf(ForkSharedProxy::class, $proxy);
     }
 }


### PR DESCRIPTION
## Summary

| Component | Description |
|-----------|-------------|
| **Issue** | #11 — SocketFactory with fallback chain |
| **Files** | `src/Server/Socket/SocketFactory.php`, `tests/Server/Socket/SocketFactoryTest.php` |
| **Changes** | Static factory with fallback: REUSE_PORT → ForkSharedProxy if unsupported |

### Acceptance criteria

- [x] `create(MASTER)` returns `MasterProxy`
- [x] `create(FORK_SHARED)` returns `ForkSharedProxy`
- [x] `create(REUSE_PORT)` returns `ReusePortProxy` if supported, else `ForkSharedProxy`
- [x] Lint + tests pass

Closes #11