### PR TITLE
M1I10: ProtocolHandlerInterface + TcpHandler

### DIFF
--- a/src/Server/Protocol/ProtocolHandlerInterface.php
+++ b/src/Server/Protocol/ProtocolHandlerInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\Forklift\Server\Protocol;
+
+use CrazyGoat\Forklift\Server\Socket\Connection;
+
+interface ProtocolHandlerInterface
+{
+    public function handle(Connection $connection): void;
+}

--- a/src/Server/Protocol/TcpHandler.php
+++ b/src/Server/Protocol/TcpHandler.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\Forklift\Server\Protocol;
+
+use CrazyGoat\Forklift\Server\Socket\Connection;
+
+class TcpHandler implements ProtocolHandlerInterface
+{
+    public function __construct(
+        /** @var \Closure(Connection): void|null */
+        private readonly ?\Closure $callback = null,
+    ) {
+    }
+
+    public function handle(Connection $connection): void
+    {
+        if ($this->callback instanceof \Closure) {
+            ($this->callback)($connection);
+        }
+    }
+}

--- a/tests/Server/Protocol/TcpHandlerTest.php
+++ b/tests/Server/Protocol/TcpHandlerTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\Forklift\Tests\Server\Protocol;
+
+use CrazyGoat\Forklift\Server\Protocol\TcpHandler;
+use CrazyGoat\Forklift\Server\Socket\Connection;
+use PHPUnit\Framework\TestCase;
+
+class TcpHandlerTest extends TestCase
+{
+    public function testNoCallbackIsNoOp(): void
+    {
+        $socket = \socket_create(AF_INET, SOCK_STREAM, SOL_TCP);
+        $this->assertNotFalse($socket);
+
+        $connection = new Connection($socket);
+        $handler = new TcpHandler();
+
+        $handler->handle($connection);
+
+        $this->assertFalse($connection->isClosed());
+
+        $connection->close();
+    }
+
+    public function testCallbackIsCalledWithConnection(): void
+    {
+        $socket = \socket_create(AF_INET, SOCK_STREAM, SOL_TCP);
+        $this->assertNotFalse($socket);
+
+        $connection = new Connection($socket);
+
+        $called = false;
+        $passedConnection = null;
+
+        $handler = new TcpHandler(function (Connection $conn) use (&$called, &$passedConnection): void {
+            $called = true;
+            $passedConnection = $conn;
+        });
+
+        $handler->handle($connection);
+
+        $this->assertTrue($called);
+        $this->assertSame($connection, $passedConnection);
+
+        $connection->close();
+    }
+
+    public function testHandlerDoesNotCloseConnection(): void
+    {
+        $socket = \socket_create(AF_INET, SOCK_STREAM, SOL_TCP);
+        $this->assertNotFalse($socket);
+
+        $connection = new Connection($socket);
+
+        $handler = new TcpHandler(function (Connection $conn): void {
+        });
+
+        $handler->handle($connection);
+
+        $this->assertFalse($connection->isClosed());
+
+        $connection->close();
+    }
+}


### PR DESCRIPTION
## Summary

| What | Where |
|------|-------|
| Create | `src/Server/Protocol/ProtocolHandlerInterface.php` |
| Create | `src/Server/Protocol/TcpHandler.php` |
| Create | `tests/Server/Protocol/TcpHandlerTest.php` |

- **ProtocolHandlerInterface** — contract with single `handle(Connection): void` method
- **TcpHandler** — implements the interface; accepts optional `Closure` callback; no-op without callback; does NOT close the connection

### Acceptance criteria
- [x] Interface has single method: `handle(Connection): void`
- [x] `TcpHandler` accepts optional Closure callback
- [x] No callback = no-op (connection accepted, nothing happens)
- [x] Handler does NOT close the connection (worker will auto-close)

Closes #12